### PR TITLE
implemtation of retrieving articles on similar topic

### DIFF
--- a/API.py
+++ b/API.py
@@ -5,6 +5,7 @@ import requests
 
 import webScraper as wS
 from biasCalculator import *
+from similarArticleRetrieval import *
 
 openai.api_key = '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'
 openai.Model.list()
@@ -72,6 +73,16 @@ def generate_response(prompt):
         temperature=0.7
     )
     return (response['choices'][0]['message']['content'])
+
+
+@app.route('/SimilarArticlesRetrieval', methods=['POST'])
+def SimilarArticlesRetrieval():
+    data = request.get_json()
+    # either a sentence summary of article  from GPT or article header 
+    input = data.get('input')
+    sortedSimilarArticles = similarArticles(input)
+
+    return [{"url" : article[0], "upper_bias" : round(article[1], 2) , "lower_bias" : round(article[2], 2)} for article in sortedSimilarArticles]
 
 if __name__ == '__main__':
     app.run()

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 pip install pymysql
 
 pip install mysql-connector-python
+
+pip install GoogleNews

--- a/biasCalculator.py
+++ b/biasCalculator.py
@@ -50,7 +50,6 @@ def biasRange(p, n, b, percentage):
     if w < n:
         w += 1 #extra -1 removed
     
-    print(w)
     y = n - w
     y_dash = math.ceil(y*(b/n))
     b_dash = b -2*y_dash + y

--- a/similarArticleRetrieval.py
+++ b/similarArticleRetrieval.py
@@ -1,0 +1,45 @@
+from GoogleNews import GoogleNews
+from webScraper import *
+from biasCalculator import *
+
+import base64
+
+def similarArticles(articleTitle):
+    googleNews = GoogleNews(lang='en')
+    googleNews.get_news(articleTitle)
+
+    similarArticles = []
+    for url in googleNews.get_links():
+        actual_url = convertGoogleNewsUrlToAccessible(url)
+
+        try:
+            ns = NewsScraper(actual_url)
+            if ns.getArticle() != None:
+                b, n, p = biasScoreGeneratorFromText(ns.getArticle())
+                b, b_dash = biasRange(p, n, b, 0.8)
+                similarArticles.append((actual_url, max([b/n,b_dash/n]), min([b/n,b_dash/n])))
+                # print(actual_url, b/n, b_dash/n)
+            else:
+                # print(f"article {actual_url} inaccessible")
+                continue
+        except:
+            # print(f"article {url} could nto be extracted")
+            continue
+
+    return sorted(similarArticles, key=lambda element: (element[1], element[2]))
+
+# need to be tested to improve extraction of url from news.google encoding
+def convertGoogleNewsUrlToAccessible(url):
+    url_in_process_A = str(base64.urlsafe_b64decode(url))
+    url_in_process_B = url_in_process_A.split("?")[1]
+    url_in_process_C = url_in_process_B.replace("https", "?https").split("?")[-1]
+    url_in_process_D = url_in_process_C.split("\\x")[0]
+    actual_url = url_in_process_D.split("/!")[0]
+    return actual_url
+
+
+sortedSimilarArticles = similarArticles("The dangerous precedent set by Trump’s indictment in Georgia")
+print([{"url" : article[0], "upper_bias" : round(article[1], 2) , "lower_bias" : round(article[2], 2)} for article in sortedSimilarArticles])
+
+# jason form
+# [{"url" : article[0], "upper_bias" : round(article[1], 2) , "lower_bias" : round(article[2], 2)} for article in sortedSimilarArticles]


### PR DESCRIPTION
implemented a retrieval of similar articles with each respective bias scores in the json format [{"url" : url, "upper_bias" : x , "lower_bias" : y}, ...]
- need to install GoogleNews (updated readme). 
- need to test what the test input needs to be to get articles that are similar to the one looked at
-  list of articles is already sorted in terms of "upper_bias" (low to high)